### PR TITLE
Remove redirect to github

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
             <p>
                 <nobr><strong>Artipie</strong> is a free binary artifact management tool.</nobr>
                 <br/>
-                <nobr><a href="https://github.com/login/oauth/authorize?client_id=0f33052d9fee8303c36e&amp;redirect_uri=https://central.artipie.com/auth">Sign in</a>
+                <nobr><a href="https://central.artipie.com/dashboard">Sign in</a>
                 to host your private repos.
                 Our <a href="https://github.com/orgs/artipie/projects/3">Roadmap</a>.</nobr>
                 <nobr>The fresh news are available at our <a href="https://blog.artipie.com/">blog</a>.</nobr>


### PR DESCRIPTION
Part of https://github.com/artipie/artipie/issues/1058

Removed redirect to github as auth via github is made internally by Artipie with `github.com/` prefix for username